### PR TITLE
adds 105 protocol support for older clients

### DIFF
--- a/src/pocketmine/network/protocol/Info.php
+++ b/src/pocketmine/network/protocol/Info.php
@@ -32,7 +32,7 @@ interface Info{
 	 */
 
 	const CURRENT_PROTOCOL = 106;
-	const ACCEPTED_PROTOCOLS = [106];
+	const ACCEPTED_PROTOCOLS = [105, 106];
 	const MINECRAFT_VERSION = "v1.0.6";
 	const MINECRAFT_VERSION_NETWORK = "1.0.6";
 


### PR DESCRIPTION
## PR Description
After updating to this latest repo, one of my regular players said they could no longer join. 
I compared the repo's and noticed the only change prohibiting the connection was the exclusion of the 105 protocol. I added it, and my player could then connect without issue. 

I also notice this repo allows connection without timeout, which is lovely. thanks !


## Have you tested it?
- [x ] I have tested it.
- [ ] I have not tested it.
...
